### PR TITLE
build: fix quartet include path

### DIFF
--- a/cmake/FindQuartet.cmake
+++ b/cmake/FindQuartet.cmake
@@ -8,7 +8,7 @@
 # It searches the environment variable $QUARTET_PATH automatically.
 
 FIND_PATH(QUARTET_INCLUDE_DIRS
-    NAMES make_tet_mesh.h
+    NAMES quartet/make_tet_mesh.h
     PATHS
     $ENV{QUARTET_PATH}
     $ENV{QUARTET_PATH}/include/


### PR DESCRIPTION
Previously the cmake recipe resultet in the following path:
  python/pymesh/third_party/include/quartet
The correct path would be:
  python/pymesh/third_party/include

The extra "quartet" suffix caused a compilation error, since the quartet
header files are referenced in the following way:
  include  <quartet/make_signed_distance.h>