### PR TITLE
build: find installed CGAL in Debian

### DIFF
--- a/cmake/FindCGAL.cmake
+++ b/cmake/FindCGAL.cmake
@@ -51,6 +51,8 @@ if ( NOT CGAL_DIR )
     # Look in standard UNIX install locations.
     /usr/local/lib/CGAL
     /usr/lib/CGAL
+    # multiarch path for CGAL in Debian
+    /usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}/cmake/CGAL
 
     # Read from the CMakeSetup registry entries.  It is likely that
     # CGAL will have been recently built.


### PR DESCRIPTION
without this change of search path it was necessary to specify the
CGAL_PATH manually (e.g. /usr/lib/i386-linux-gnu/cmake/CGAL)